### PR TITLE
Create docker-compose equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # temporal-render-simple
-temporal-render-simple
+
+Example repo to show how to deploy a simple version of Temporal to Render.com - using the [Auto-Setup Docker image](https://docs.temporal.io/blog/auto-setup). This is not recommended for production beyond small usecases, as all 4 Temporal internal services (Frontend, Matching, History, and Worker) are being run out of one process, but the benefit is that setup is also a lot easier.
+
+### One Click
+
+Use the button below to deploy Temporal on Render.
+
+[![Deploy to Render](http://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)

--- a/admin-tools/Dockerfile
+++ b/admin-tools/Dockerfile
@@ -1,1 +1,1 @@
-FROM temporalio/admin-tools:1.14.0
+FROM temporalio/admin-tools:1.14.3

--- a/admin-tools/Dockerfile
+++ b/admin-tools/Dockerfile
@@ -1,0 +1,1 @@
+FROM temporalio/admin-tools:1.14.0

--- a/config/dynamicconfig.yaml
+++ b/config/dynamicconfig.yaml
@@ -1,0 +1,29 @@
+frontend.enableClientVersionCheck:
+- value: true
+  constraints: {}
+history.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.throttledLogRPS:
+- value: 20
+  constraints: {}
+history.defaultActivityRetryPolicy:
+- value:
+    InitialIntervalInSeconds: 1
+    MaximumIntervalCoefficient: 100.0
+    BackoffCoefficient: 2.0
+    MaximumAttempts: 0
+history.defaultWorkflowRetryPolicy:
+- value:
+    InitialIntervalInSeconds: 1
+    MaximumIntervalCoefficient: 100.0
+    BackoffCoefficient: 2.0
+    MaximumAttempts: 0
+system.advancedVisibilityWritingMode:
+  - value: "off"
+    constraints: {}
+#system.enableParentClosePolicyWorker:
+#  - value: true

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,74 @@
+databases:
+- name: temporal
+  databaseName: temporal
+  user: temporal
+  plan: standard
+
+services:
+- type: pserv
+  name: temporal
+  autoDeploy: false
+  plan: Standard
+  env: docker
+  dockerfilePath: ./server/Dockerfile
+  envVars:
+  - key: PORT
+    value: 7233
+  - key: DYNAMIC_CONFIG_FILE_PATH
+    value: /etc/temporal/dynamicconfig.yaml
+  - key: SKIP_POSTGRES_DB_CREATION
+    value: true # Render creates the database when the DB is created
+  - key: DB
+    value: postgresql
+  - key: DBNAME
+    fromDatabase:
+      name: temporal
+      property: database
+  - key: VISIBILITY_DBNAME
+    fromDatabase:
+      name: temporal
+      property: database
+  - key: DB_PORT
+    fromDatabase:
+      name: temporal
+      property: port
+  - key: POSTGRES_USER
+    fromDatabase:
+      name: temporal
+      property: user
+  - key: POSTGRES_PWD
+    fromDatabase:
+      name: temporal
+      property: password
+  - key: POSTGRES_SEEDS
+    fromDatabase:
+      name: temporal
+      property: host
+- type: worker
+  name: temporal-admin-tools
+  autoDeploy: false
+  plan: Standard
+  env: docker
+  dockerfilePath: ./admin-tools/Dockerfile
+  envVars:
+  - key: TEMPORAL_CLI_ADDRESS
+    fromService:
+      name: temporal
+      type: pserv
+      property: hostport
+- type: web
+  name: temporal-web
+  autoDeploy: false
+  plan: Standard
+  env: docker
+  dockerfilePath: ./web/Dockerfile
+  envVars:
+  - key: PORT
+    value: 8088
+  - key: TEMPORAL_PERMIT_WRITE_API
+    value: true
+  - key: TEMPORAL_GRPC_ENDPOINT
+    fromService:
+      name: temporal
+      type: pserv
+      property: hostport

--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,7 @@ databases:
   plan: standard
 
 services:
-- type: pserv
+- type: web
   name: temporal
   autoDeploy: false
   plan: Standard

--- a/render.yaml
+++ b/render.yaml
@@ -74,7 +74,7 @@ services:
   - key: TEMPORAL_CLI_ADDRESS
     fromService:
       name: temporal
-      type: pserv
+      type: web
       property: hostport
 - type: web
   name: temporal-web
@@ -90,5 +90,5 @@ services:
   - key: TEMPORAL_GRPC_ENDPOINT
     fromService:
       name: temporal
-      type: pserv
+      type: web
       property: hostport

--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,10 @@ databases:
   databaseName: temporal
   user: temporal
   plan: standard
+- name: temporal-visibility
+  databaseName: visibility
+  user: visibility
+  plan: standard
 
 services:
 - type: pserv
@@ -24,10 +28,6 @@ services:
     fromDatabase:
       name: temporal
       property: database
-  - key: VISIBILITY_DBNAME
-    fromDatabase:
-      name: temporal
-      property: database
   - key: DB_PORT
     fromDatabase:
       name: temporal
@@ -43,6 +43,26 @@ services:
   - key: POSTGRES_SEEDS
     fromDatabase:
       name: temporal
+      property: host
+  - key: VISIBILITY_DBNAME
+    fromDatabase:
+      name: temporal-visibility
+      property: database
+  - key: VISIBILITY_DB_PORT
+    fromDatabase:
+      name: temporal-visibility
+      property: port
+  - key: VISIBILITY_POSTGRES_USER
+    fromDatabase:
+      name: temporal-visibility
+      property: user
+  - key: VISIBILITY_POSTGRES_PWD
+    fromDatabase:
+      name: temporal-visibility
+      property: password
+  - key: VISIBILITY_POSTGRES_SEEDS
+    fromDatabase:
+      name: temporal-visibility
       property: host
 - type: worker
   name: temporal-admin-tools

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM temporalio/auto-setup:1.14.0
+FROM temporalio/auto-setup:1.14.3
 
 # Docker context is set to the root of this repo
 COPY config/dynamicconfig.yaml /etc/temporal/dynamicconfig.yaml

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,5 @@
+FROM temporalio/auto-setup:1.14.0
+
+# Docker context is set to the root of this repo
+COPY config/dynamicconfig.yaml /etc/temporal/dynamicconfig.yaml
+COPY server/auto-setup.sh .

--- a/server/auto-setup.sh
+++ b/server/auto-setup.sh
@@ -184,13 +184,13 @@ setup_postgres_schema() {
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
 
+    { export SQL_PASSWORD=${VISIBILITY_POSTGRES_PWD}; } 2> /dev/null
     VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/visibility/versioned
     if [[ "${VISIBILITY_DBNAME}" != "${POSTGRES_USER}" && "${SKIP_POSTGRES_DB_CREATION}" != true ]]; then
-        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+        temporal-sql-tool --plugin postgres --ep "${VISIBILITY_POSTGRES_SEEDS}" -u "${VISIBILITY_POSTGRES_USER}" -p "${VISIBILITY_DB_PORT}" create --db "${VISIBILITY_DBNAME}"
     fi
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
-# TODO uncomment when fixed
-#    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+    temporal-sql-tool --plugin postgres --ep "${VISIBILITY_POSTGRES_SEEDS}" -u "${VISIBILITY_POSTGRES_USER}" -p "${VISIBILITY_DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
+    temporal-sql-tool --plugin postgres --ep "${VISIBILITY_POSTGRES_SEEDS}" -u "${VISIBILITY_POSTGRES_USER}" -p "${VISIBILITY_DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
 }
 
 setup_schema() {

--- a/server/auto-setup.sh
+++ b/server/auto-setup.sh
@@ -189,7 +189,8 @@ setup_postgres_schema() {
         temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
     fi
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+# TODO uncomment when fixed
+#    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
 }
 
 setup_schema() {

--- a/server/auto-setup.sh
+++ b/server/auto-setup.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# === Auto setup defaults ===
+
+DB="${DB:-cassandra}"
+SKIP_SCHEMA_SETUP="${SKIP_SCHEMA_SETUP:-false}"
+
+# Cassandra
+KEYSPACE="${KEYSPACE:-temporal}"
+VISIBILITY_KEYSPACE="${VISIBILITY_KEYSPACE:-temporal_visibility}"
+
+CASSANDRA_SEEDS="${CASSANDRA_SEEDS:-}"
+CASSANDRA_PORT="${CASSANDRA_PORT:-9042}"
+CASSANDRA_USER="${CASSANDRA_USER:-}"
+CASSANDRA_PASSWORD="${CASSANDRA_PASSWORD:-}"
+CASSANDRA_TLS_ENABLED="${CASSANDRA_TLS_ENABLED:-}"
+CASSANDRA_CERT="${CASSANDRA_CERT:-}"
+CASSANDRA_CERT_KEY="${CASSANDRA_CERT_KEY:-}"
+CASSANDRA_CA="${CASSANDRA_CA:-}"
+CASSANDRA_REPLICATION_FACTOR="${CASSANDRA_REPLICATION_FACTOR:-1}"
+
+# MySQL/PostgreSQL
+DBNAME="${DBNAME:-temporal}"
+VISIBILITY_DBNAME="${VISIBILITY_DBNAME:-temporal_visibility}"
+DB_PORT="${DB_PORT:-3306}"
+
+MYSQL_SEEDS="${MYSQL_SEEDS:-}"
+MYSQL_USER="${MYSQL_USER:-}"
+MYSQL_PWD="${MYSQL_PWD:-}"
+MYSQL_TX_ISOLATION_COMPAT="${MYSQL_TX_ISOLATION_COMPAT:-false}"
+
+POSTGRES_SEEDS="${POSTGRES_SEEDS:-}"
+POSTGRES_USER="${POSTGRES_USER:-}"
+POSTGRES_PWD="${POSTGRES_PWD:-}"
+# Don't create the DB instance
+SKIP_POSTGRES_DB_CREATION="${SKIP_POSTGRES_DB_CREATION:-false}"
+
+# Elasticsearch
+ENABLE_ES="${ENABLE_ES:-false}"
+ES_SCHEME="${ES_SCHEME:-http}"
+ES_SEEDS="${ES_SEEDS:-}"
+ES_PORT="${ES_PORT:-9200}"
+ES_USER="${ES_USER:-}"
+ES_PWD="${ES_PWD:-}"
+ES_VERSION="${ES_VERSION:-v7}"
+ES_VIS_INDEX="${ES_VIS_INDEX:-temporal_visibility_v1_dev}"
+ES_SCHEMA_SETUP_TIMEOUT_IN_SECONDS="${ES_SCHEMA_SETUP_TIMEOUT_IN_SECONDS:-0}"
+
+# Server setup
+TEMPORAL_CLI_ADDRESS="${TEMPORAL_CLI_ADDRESS:-}"
+
+SKIP_DEFAULT_NAMESPACE_CREATION="${SKIP_DEFAULT_NAMESPACE_CREATION:-false}"
+DEFAULT_NAMESPACE="${DEFAULT_NAMESPACE:-default}"
+DEFAULT_NAMESPACE_RETENTION=${DEFAULT_NAMESPACE_RETENTION:-1}
+
+SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES="${SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES:-false}"
+
+# === Main database functions ===
+
+validate_db_env() {
+    if [ "${DB}" == "mysql" ]; then
+        if [ -z "${MYSQL_SEEDS}" ]; then
+            echo "MYSQL_SEEDS env must be set if DB is ${DB}."
+            exit 1
+        fi
+    elif [ "${DB}" == "postgresql" ]; then
+        if [ -z "${POSTGRES_SEEDS}" ]; then
+            echo "POSTGRES_SEEDS env must be set if DB is ${DB}."
+            exit 1
+        fi
+    elif [ "${DB}" == "cassandra" ]; then
+        if [ -z "${CASSANDRA_SEEDS}" ]; then
+            echo "CASSANDRA_SEEDS env must be set if DB is ${DB}."
+            exit 1
+        fi
+    else
+        echo "Unsupported DB type: ${DB}."
+        exit 1
+    fi
+}
+
+wait_for_cassandra() {
+    # TODO (alex): Remove exports
+    export CASSANDRA_USER=${CASSANDRA_USER}
+    export CASSANDRA_PORT=${CASSANDRA_PORT}
+    export CASSANDRA_ENABLE_TLS=${CASSANDRA_TLS_ENABLED}
+    export CASSANDRA_TLS_CERT=${CASSANDRA_CERT}
+    export CASSANDRA_TLS_KEY=${CASSANDRA_CERT_KEY}
+    export CASSANDRA_TLS_CA=${CASSANDRA_CA}
+
+    { export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}; } 2> /dev/null
+
+    until temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" validate-health; do
+        echo 'Waiting for Cassandra to start up.'
+        sleep 1
+    done
+    echo 'Cassandra started.'
+}
+
+wait_for_mysql() {
+    until nc -z "${MYSQL_SEEDS%%,*}" "${DB_PORT}"; do
+        echo 'Waiting for MySQL to start up.'
+        sleep 1
+    done
+
+    echo 'MySQL started.'
+}
+
+wait_for_postgres() {
+    until nc -z "${POSTGRES_SEEDS%%,*}" "${DB_PORT}"; do
+        echo 'Waiting for PostgreSQL to startup.'
+        sleep 1
+    done
+
+    echo 'PostgreSQL started.'
+}
+
+wait_for_db() {
+    if [ "${DB}" == "mysql" ]; then
+        wait_for_mysql
+    elif [ "${DB}" == "postgresql" ]; then
+        wait_for_postgres
+    elif [ "${DB}" == "cassandra" ]; then
+        wait_for_cassandra
+    else
+        echo "Unsupported DB type: ${DB}."
+        exit 1
+    fi
+}
+
+setup_cassandra_schema() {
+    # TODO (alex): Remove exports
+    export CASSANDRA_USER=${CASSANDRA_USER}
+    export CASSANDRA_PORT=${CASSANDRA_PORT}
+    export CASSANDRA_ENABLE_TLS=${CASSANDRA_TLS_ENABLED}
+    export CASSANDRA_TLS_CERT=${CASSANDRA_CERT}
+    export CASSANDRA_TLS_KEY=${CASSANDRA_CERT_KEY}
+    export CASSANDRA_TLS_CA=${CASSANDRA_CA}
+
+    { export CASSANDRA_PASSWORD=${CASSANDRA_PASSWORD}; } 2> /dev/null
+
+    SCHEMA_DIR=${TEMPORAL_HOME}/schema/cassandra/temporal/versioned
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" create -k "${KEYSPACE}" --rf "${CASSANDRA_REPLICATION_FACTOR}"
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" -k "${KEYSPACE}" setup-schema -v 0.0
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" -k "${KEYSPACE}" update-schema -d "${SCHEMA_DIR}"
+
+    VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/cassandra/visibility/versioned
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" create -k "${VISIBILITY_KEYSPACE}" --rf "${CASSANDRA_REPLICATION_FACTOR}"
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" -k "${VISIBILITY_KEYSPACE}" setup-schema -v 0.0
+    temporal-cassandra-tool --ep "${CASSANDRA_SEEDS}" -k "${VISIBILITY_KEYSPACE}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+}
+
+setup_mysql_schema() {
+    # TODO (alex): Remove exports
+    { export SQL_PASSWORD=${MYSQL_PWD}; } 2> /dev/null
+
+    if [ "${MYSQL_TX_ISOLATION_COMPAT}" == "true" ]; then
+        MYSQL_CONNECT_ATTR=(--connect-attributes "tx_isolation=READ-COMMITTED")
+    else
+        MYSQL_CONNECT_ATTR=()
+    fi
+
+    SCHEMA_DIR=${TEMPORAL_HOME}/schema/mysql/v57/temporal/versioned
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" create --db "${DBNAME}"
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" --db "${DBNAME}" setup-schema -v 0.0
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
+    VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/mysql/v57/visibility/versioned
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" create --db "${VISIBILITY_DBNAME}"
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
+    temporal-sql-tool --ep "${MYSQL_SEEDS}" -u "${MYSQL_USER}" "${MYSQL_CONNECT_ATTR[@]}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+}
+
+setup_postgres_schema() {
+    # TODO (alex): Remove exports
+    { export SQL_PASSWORD=${POSTGRES_PWD}; } 2> /dev/null
+
+    SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/temporal/versioned
+    # Create database only if its name is different from the user name. Otherwise PostgreSQL container itself will create database.
+    if [[ "${DBNAME}" != "${POSTGRES_USER}" && "${SKIP_POSTGRES_DB_CREATION}" != true ]]; then
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
+    fi
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
+
+    VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/visibility/versioned
+    if [[ "${VISIBILITY_DBNAME}" != "${POSTGRES_USER}" && "${SKIP_POSTGRES_DB_CREATION}" != true ]]; then
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+    fi
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
+    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
+}
+
+setup_schema() {
+    if [ "${DB}" == "mysql" ]; then
+        echo 'Setup MySQL schema.'
+        setup_mysql_schema
+    elif [ "${DB}" == "postgresql" ]; then
+        echo 'Setup PostgreSQL schema.'
+        setup_postgres_schema
+    else
+        echo 'Setup Cassandra schema.'
+        setup_cassandra_schema
+    fi
+}
+
+# === Elasticsearch functions ===
+
+validate_es_env() {
+    if [ "${ENABLE_ES}" == true ]; then
+        if [ -z "${ES_SEEDS}" ]; then
+            echo "ES_SEEDS env must be set if ENABLE_ES is ${ENABLE_ES}"
+            exit 1
+        fi
+    fi
+}
+
+wait_for_es() {
+    SECONDS=0
+
+    ES_SERVER="${ES_SCHEME}://${ES_SEEDS%%,*}:${ES_PORT}"
+
+    until curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${ES_SERVER}" > /dev/null 2>&1; do
+        DURATION=${SECONDS}
+
+        if [ "${ES_SCHEMA_SETUP_TIMEOUT_IN_SECONDS}" -gt 0 ] && [ ${DURATION} -ge "${ES_SCHEMA_SETUP_TIMEOUT_IN_SECONDS}" ]; then
+            echo 'WARNING: timed out waiting for Elasticsearch to start up. Skipping index creation.'
+            return;
+        fi
+
+        echo 'Waiting for Elasticsearch to start up.'
+        sleep 1
+    done
+
+    echo 'Elasticsearch started.'
+}
+
+setup_es_index() {
+    ES_SERVER="${ES_SCHEME}://${ES_SEEDS%%,*}:${ES_PORT}"
+# @@@SNIPSTART setup-es-template-commands
+    # ES_SERVER is the URL of Elasticsearch server i.e. "http://localhost:9200".
+    SETTINGS_URL="${ES_SERVER}/_cluster/settings"
+    SETTINGS_FILE=${TEMPORAL_HOME}/schema/elasticsearch/visibility/cluster_settings_${ES_VERSION}.json
+    TEMPLATE_URL="${ES_SERVER}/_template/temporal_visibility_v1_template"
+    SCHEMA_FILE=${TEMPORAL_HOME}/schema/elasticsearch/visibility/index_template_${ES_VERSION}.json
+    INDEX_URL="${ES_SERVER}/${ES_VIS_INDEX}"
+    curl --fail --user "${ES_USER}":"${ES_PWD}" -X PUT "${SETTINGS_URL}" -H "Content-Type: application/json" --data-binary "@${SETTINGS_FILE}" --write-out "\n"
+    curl --fail --user "${ES_USER}":"${ES_PWD}" -X PUT "${TEMPLATE_URL}" -H 'Content-Type: application/json' --data-binary "@${SCHEMA_FILE}" --write-out "\n"
+    curl --user "${ES_USER}":"${ES_PWD}" -X PUT "${INDEX_URL}" --write-out "\n"
+# @@@SNIPEND
+}
+
+# === Server setup ===
+
+register_default_namespace() {
+    echo "Registering default namespace: ${DEFAULT_NAMESPACE}."
+    if ! tctl --ns "${DEFAULT_NAMESPACE}" namespace describe; then
+        echo "Default namespace ${DEFAULT_NAMESPACE} not found. Creating..."
+        tctl --ns "${DEFAULT_NAMESPACE}" namespace register --rd "${DEFAULT_NAMESPACE_RETENTION}" --desc "Default namespace for Temporal Server."
+        echo "Default namespace ${DEFAULT_NAMESPACE} registration complete."
+    else
+        echo "Default namespace ${DEFAULT_NAMESPACE} already registered."
+    fi
+}
+
+add_custom_search_attributes() {
+      echo "Adding Custom*Field search attributes."
+      # TODO: Remove CustomStringField
+# @@@SNIPSTART add-custom-search-attributes-for-testing-command
+      tctl --auto_confirm admin cluster add-search-attributes \
+          --name CustomKeywordField --type Keyword \
+          --name CustomStringField --type Text \
+          --name CustomTextField --type Text \
+          --name CustomIntField --type Int \
+          --name CustomDatetimeField --type Datetime \
+          --name CustomDoubleField --type Double \
+          --name CustomBoolField --type Bool
+# @@@SNIPEND
+}
+
+setup_server(){
+    echo "Temporal CLI address: ${TEMPORAL_CLI_ADDRESS}."
+
+    until tctl cluster health | grep SERVING; do
+        echo "Waiting for Temporal server to start..."
+        sleep 1
+    done
+    echo "Temporal server started."
+
+    if [ "${SKIP_DEFAULT_NAMESPACE_CREATION}" != true ]; then
+        register_default_namespace
+    fi
+
+    if [ "${SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES}" != true ]; then
+        add_custom_search_attributes
+    fi
+}
+
+# === Main ===
+
+if [ "${SKIP_SCHEMA_SETUP}" != true ]; then
+    validate_db_env
+    wait_for_db
+    setup_schema
+fi
+
+if [ "${ENABLE_ES}" == true ]; then
+    validate_es_env
+    wait_for_es
+    setup_es_index
+fi
+
+# Run this func in parallel process. It will wait for server to start and then run required steps.
+setup_server &

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,1 @@
+FROM temporalio/web:1.13.0


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Temporal's `docker-compose` for PostgreSQL was translated to a Render Blueprint spec. The spec (`render.yaml`) should work to bring the servers up, but we need the ability to create multiple DBs in the same instance on Render, or allow Temporal `auto-setup.sh` to use a different database instance for `VISIBILITY`.

## Why?
<!-- Tell your future self why have you made these changes -->
It allows devs to kick the tires on Temporal in the cloud quickly.
## Checklist
<!--- add/delete as needed --->
- [x] Create a Deploy to Render button
- [x] Fix the issue with `VISIBILITY` DB